### PR TITLE
fix(modules): resolve babel-runtime etc. from meteor bundle

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,8 +1,7 @@
 {
   "presets": ["es2015", "stage-1", "react", "flow"],
   "plugins": [
-    "transform-runtime",
-    "meteor-imports"
+    "transform-runtime"
   ],
   "env": {
     "coverage": {
@@ -17,3 +16,4 @@
     }
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint:watch": "esw -w *.js src scripts test util webpack"
   },
   "dependencies": {
-    "babel-runtime": "^6.11.6",
+    "babel-plugin-module-resolver": "^2.7.1",
     "bcrypt": "^1.0.1",
     "debug": "^2.5.2",
     "es6-promisify": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "babel-preset-react": "^6.11.1",
     "babel-preset-stage-1": "^6.13.0",
     "babel-register": "^6.14.0",
+    "babel-runtime": "^6.23.0",
     "chai": "^3.5.0",
     "coveralls": "^2.11.15",
     "crater-util": "^1.2.2",

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,6 +1,7 @@
 {
-  "extends": "../.babelrc",
+  "presets": ["es2015", "stage-1", "react", "flow"],
   "plugins": [
+    ["transform-runtime", {"polyfill": false, "helpers": false}],
     "meteor-imports",
     ["module-resolver", {
       "root": [
@@ -8,5 +9,11 @@
         "./build/meteor/bundle/programs/server/npm/node_modules"
       ]
     }]
-  ]
+  ],
+  "env": {
+    "coverage": {
+      "plugins": ["istanbul"]
+    }
+  }
 }
+

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -4,10 +4,10 @@
     ["transform-runtime", {"polyfill": false, "helpers": false}],
     "meteor-imports",
     ["module-resolver", {
-      "root": [
-        "./build/meteor/bundle/programs/server/node_modules",
-        "./build/meteor/bundle/programs/server/npm/node_modules"
-      ]
+      "root": ["./build/meteor/bundle/programs/server/npm/node_modules"],
+      "alias": {
+        "fibers": "./build/meteor/bundle/programs/server/node_modules/fibers"
+      }
     }]
   ],
   "env": {

--- a/src/.babelrc
+++ b/src/.babelrc
@@ -1,0 +1,12 @@
+{
+  "extends": "../.babelrc",
+  "plugins": [
+    "meteor-imports",
+    ["module-resolver", {
+      "root": [
+        "./build/meteor/bundle/programs/server/node_modules",
+        "./build/meteor/bundle/programs/server/npm/node_modules"
+      ]
+    }]
+  ]
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -5,7 +5,6 @@ import path from 'path'
 import createSSR from './createSSR'
 import { WebApp } from 'meteor/webapp'
 import createDebug from 'debug'
-import Fiber from 'fibers'
 
 const buildDir = process.env.BUILD_DIR
 if (!buildDir) throw new Error("missing process.env.BUILD_DIR")
@@ -39,7 +38,7 @@ app.get('*', (req: Object, res: Object, next: Function) => {
     next()
     return
   }
-  Fiber((): void => createSSR(req, res)).run()
+  createSSR(req, res)
 })
 
 WebApp.rawConnectHandlers.use(app)

--- a/webpack/webpack.config.dev.js
+++ b/webpack/webpack.config.dev.js
@@ -14,11 +14,11 @@ const srcDir = path.join(root, 'src')
 const globalCSS = path.join(srcDir, 'styles', 'global')
 const clientInclude = [srcDir]
 
-const { ROOT_URL } = process.env
+const { ROOT_URL, WEBPACK_DEVTOOL } = process.env
 
 const config = {
   context: root,
-  devtool: 'eval',
+  devtool: WEBPACK_DEVTOOL || 'eval',
   entry: [
     './src/client/index.js',
     'react-hot-loader/patch',

--- a/webpack/webpack.config.prod.js
+++ b/webpack/webpack.config.prod.js
@@ -22,7 +22,7 @@ const vendor = [
 
 const config = {
   context: root,
-  devtool: 'source-map',
+  devtool: process.env.WEBPACK_DEVTOOL || 'source-map',
   entry: {
     app: './src/client/index.js',
     vendor,
@@ -100,7 +100,7 @@ const config = {
 
 /* istanbul ignore next */
 if (!process.env.CI) config.plugins.push(new ProgressBarPlugin())
-if (process.argv.indexOf('--no-uglify') < 0) {
+if (!process.env.NO_UGLIFY && process.argv.indexOf('--no-uglify') < 0) {
   config.plugins.push(new webpack.optimize.UglifyJsPlugin({
     compressor: { warnings: false }
   }))

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -15,7 +15,7 @@ const globalCSS = path.join(srcDir, 'styles', 'global')
 
 const config = {
   context: root,
-  devtool: 'source-map',
+  devtool: process.env.WEBPACK_DEVTOOL || 'source-map',
   entry: {
     prerender: './src/server',
   },

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -36,13 +36,14 @@ const config = {
     nodeExternals({
       modulesDir: path.join(root, 'node_modules'),
     }),
-    // (context: string, request: string, callback: (error?: ?Error, result?: ?string) => any): any => {
-    //   const match = /^meteor\/(.*)$/.exec(request)
-    //   if (match) {
-    //     return callback(null, 'var Package.' + match[1].replace(/\//g, '.'))
-    //   }
-    //   callback()
-    // },
+    (context, request, callback) => {
+      // require anything in build/meteor/bundle/programs/server/* via node
+      const match = /meteor\/bundle\/programs\/server\/.*$/.exec(request)
+      if (match) {
+        return callback(null, 'commonjs ./' + match[0])
+      }
+      callback()
+    },
   ],
   plugins: [
     new webpack.NoErrorsPlugin(),

--- a/webpack/webpack.config.server.js
+++ b/webpack/webpack.config.server.js
@@ -36,7 +36,7 @@ const config = {
     nodeExternals({
       modulesDir: path.join(root, 'node_modules'),
     }),
-    (context, request, callback) => {
+    (context: string, request: string, callback: (error?: ?Error, request?: string) => any): any => {
       // require anything in build/meteor/bundle/programs/server/* via node
       const match = /meteor\/bundle\/programs\/server\/.*$/.exec(request)
       if (match) {


### PR DESCRIPTION
i.e. from
* `build/meteor/bundle/programs/server/node_modules`
* `build/meteor/bundle/programs/server/npm/node_modules`

instead of from root `node_modules`.  Hopefully this will solve #162
by avoiding duplicate instances of `Promise`, `Fiber`, etc.